### PR TITLE
Fix DR arrow heading

### DIFF
--- a/src/components/DualTrackingTest.jsx
+++ b/src/components/DualTrackingTest.jsx
@@ -267,8 +267,8 @@ export default function DualTrackingTest({ mode, actions, mapHeight }) {
                     {drPath.length > 0 && (
                         <DrArrowMarker
                             position={drPath[drPath.length - 1]}
-                            // heading={getCalibratedHeading()} // ✅ استفاده از جهت کالیبره‌شده
-                            heading={calcDrHeading(drPath)} // ✅ استفاده از جهت محاسبه شده مسیر DR
+                            heading={getCalibratedHeading()} // ✅ استفاده از جهت کالیبره‌شده
+                            // heading={calcDrHeading(drPath)} // استفاده از جهت محاسبه شده مسیر DR
                         />
                     )}
                     <AutoRecenter gps={lastGps} dr={lastDr} mode={followMode} />


### PR DESCRIPTION
## Summary
- use calibrated heading for DR arrow marker so orientation matches compass

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6843fb86f23083328093e3ecedbd63bd