### PR TITLE
Fix polygons missing from JSON export

### DIFF
--- a/src/components/localStorageHooks.jsx
+++ b/src/components/localStorageHooks.jsx
@@ -375,7 +375,8 @@ const exportMapData = (format = 'geojson') => {
         version: '1.0',
         exportDate: new Date().toISOString(),
         markers,
-        paths
+        paths,
+        polygons
       };
       dataStr = JSON.stringify(exportData, null, 2);
       mimeType = 'application/json';


### PR DESCRIPTION
## Summary
- ensure polygons array is included when exporting JSON

## Testing
- `npm run` *(shows no test script)*

------
https://chatgpt.com/codex/tasks/task_e_6843f9b89d1c83328d540f01df5fe32a