### PR TITLE
Fix missing Leaflet import

### DIFF
--- a/src/components/DeletionModal.jsx
+++ b/src/components/DeletionModal.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import L from 'leaflet';
 import {
     Dialog,
     DialogTitle,


### PR DESCRIPTION
## Summary
- fix ReferenceError in `DeletionModal` by importing Leaflet

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6843f4986ef48332846d34d444b900fa