### PR TITLE
Update Node.js LTS version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Built with:
 
 ## Prerequisites
 
-* **Node.js** v22.14.0
+* **Node.js** v20.14.0 (LTS)
 * **npm** v10.9.2
 * Windows, macOS, or Linux development environment
 


### PR DESCRIPTION
## Summary
- reference Node.js v20.14.0 LTS in prerequisites

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6843f9b6a7608332a6e8db8b82d4053b