### PR TITLE
Fix heading calculation formulas

### DIFF
--- a/src/components/DualTrackingTest.jsx
+++ b/src/components/DualTrackingTest.jsx
@@ -31,7 +31,7 @@ function calcDrHeading(path) {
     let bearing = Math.atan2(y, x) * 180 / Math.PI;
     
     // ✅ تصحیح فرمول - تبدیل از mathematical bearing به geographic bearing
-    bearing = (90 - bearing + 360) % 360;
+    bearing = (bearing + 360) % 360;
 
     return bearing;
 }
@@ -53,7 +53,7 @@ function calcGpsMovementDirection(points) {
     let bearing = Math.atan2(y, x) * 180 / Math.PI;
     
     // ✅ همین تصحیح برای GPS هم
-    bearing = (90 - bearing + 360) % 360;
+    bearing = (bearing + 360) % 360;
 
     return bearing;
 }


### PR DESCRIPTION
## Summary
- correct heading formulas in `calcDrHeading` and `calcGpsMovementDirection`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844064d7ce883328b9de1e9daeb2352