### PR TITLE
Fix duplicate polygon storage hook

### DIFF
--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -203,7 +203,6 @@ const Map = () => {
   const [polygonPoints, setPolygonPoints] = useState([]);
   const [showPolygonModal, setShowPolygonModal] = useState(false);
   const blockNextMapClickRef = useRef(false);
-  const { polygons, addPolygon, removePolygon } = usePolygonStorage();
   const [drPanelOpen, setDrPanelOpen] = useState(false);
 
   const [clickPos, setClickPos] = useState(null);


### PR DESCRIPTION
## Summary
- remove early polygon storage hook reference in `Map.jsx`
- keep the later declaration that includes `updatePolygon`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68483a38640c8332951e4913cde5ee71