### PR TITLE
Fix polygon click and default group inheritance

### DIFF
--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -307,8 +307,16 @@ function getPolygonDefaults(point, polygons) {
 // Check if a point lies inside a polygon using Turf.js
 function isPointInPolygon(point, polygon) {
   try {
+    const coords = Array.isArray(polygon) ? [...polygon] : [];
+    if (
+      coords.length > 0 &&
+      (coords[0][0] !== coords[coords.length - 1][0] ||
+        coords[0][1] !== coords[coords.length - 1][1])
+    ) {
+      coords.push(coords[0]);
+    }
     const pt = turfPoint([point.lng, point.lat]);
-    const poly = turfPolygon([polygon.map(([lat, lng]) => [lng, lat])]);
+    const poly = turfPolygon([coords.map(([lat, lng]) => [lng, lat])]);
     const result = pointsWithinPolygon(featureCollection([pt]), poly);
     return result.features.length > 0;
   } catch (error) {
@@ -1085,7 +1093,7 @@ const Map = () => {
         {isDrawingPolygon && polygonPoints.length > 1 && (
           <Polygon
             positions={polygonPoints}
-            pathOptions={{ color: 'black', fill: false, fillOpacity: 0 , opacity: 0.5}}
+            pathOptions={{ color: 'black', fillOpacity: 0, opacity: 0.5 }}
           />
         )}
 
@@ -1093,7 +1101,7 @@ const Map = () => {
           <Polygon
             key={polygon.id}
             positions={polygon.coordinates}
-            pathOptions={{ color: 'black', fill: false, fillOpacity: 0 , opacity: 0.5}}
+            pathOptions={{ color: 'black', fillOpacity: 0, opacity: 0.5 }}
             eventHandlers={{
               click: (e) => {
                 if (e.originalEvent && e.originalEvent.stopPropagation) {


### PR DESCRIPTION
## Summary
- fix isPointInPolygon to handle open polygons
- keep polygons interactive by removing `fill: false`
- keep fill invisible while still clickable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6863a8fbe1d083328c22afb64dd58cb6