### PR TITLE
Fix marker group defaults

### DIFF
--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -298,7 +298,11 @@ const functionIcons = {
 function getPolygonDefaults(point, polygons) {
   for (const pg of polygons) {
     if (pg.coordinates && isPointInPolygon(point, pg.coordinates)) {
-      return { group: pg.group || '', subGroup: pg.subGroup || '' };
+      return {
+        group: pg.group || '',
+        subGroup: pg.subGroup || '',
+        subGroupValue: pg.subGroupValue || ''
+      };
     }
   }
   return null;


### PR DESCRIPTION
## Summary
- ensure subGroupValue is passed when checking polygon defaults

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6863ad2d6c488332a72743ad0c606d2d