### PR TITLE
Fix polygon group defaults

### DIFF
--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -312,8 +312,15 @@ function getPolygonDefaults(point, polygons) {
 function isPointInPolygon(point, polygon) {
   try {
     const pt = turfPoint([point.lng, point.lat]);
-    const poly = turfPolygon([polygon.map(([lat, lng]) => [lng, lat])]);
-    const result = pointsWithinPolygon(featureCollection([pt]), poly);
+
+    // Attempt assuming polygon coordinates are [lat, lng]
+    let poly = turfPolygon([polygon.map(([lat, lng]) => [lng, lat])]);
+    let result = pointsWithinPolygon(featureCollection([pt]), poly);
+    if (result.features.length > 0) return true;
+
+    // Fallback for polygons saved as [lng, lat]
+    poly = turfPolygon([polygon]);
+    result = pointsWithinPolygon(featureCollection([pt]), poly);
     return result.features.length > 0;
   } catch (error) {
     console.error('Error in isPointInPolygon:', error);


### PR DESCRIPTION
## Summary
- fix detection of marker within polygons
- allow polygons stored as `[lng,lat]` as well as `[lat,lng]`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6863af612a5c83329ddc1f5bdd18ab73