### PR TITLE
Fix polygon group/subGroup import

### DIFF
--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -471,9 +471,13 @@ const Map = () => {
                 id: crypto.randomUUID(),
                 name: properties.name || '',
                 description: properties.description || '',
-                type: properties.type || '',
-                transportModes: properties.transportModes || [],
+                group: properties.group || '',
+                subGroup: properties.subGroup || '',
+                subGroupValue: properties.subGroupValue || '',
+                types: properties.types || (properties.type ? [properties.type] : []),
+                services: properties.transportModes || properties.services || {},
                 gender: properties.gender || '',
+                restrictedTimes: properties.restrictedTimes || [],
                 coordinates: coords,
                 timestamp: properties.timestamp || new Date().toISOString()
               });

--- a/src/components/localStorageHooks.jsx
+++ b/src/components/localStorageHooks.jsx
@@ -494,9 +494,13 @@ const importMapData = (file) => {
               id: crypto.randomUUID(),
               name: properties.name || '',
               description: properties.description || '',
-              type: properties.type || '',
-              transportModes: properties.transportModes || [],
+              group: properties.group || '',
+              subGroup: properties.subGroup || '',
+              subGroupValue: properties.subGroupValue || '',
+              types: properties.types || (properties.type ? [properties.type] : []),
+              services: properties.transportModes || properties.services || {},
               gender: properties.gender || '',
+              restrictedTimes: properties.restrictedTimes || [],
               coordinates: coords,
               timestamp: properties.timestamp || new Date().toISOString()
             });


### PR DESCRIPTION
## Summary
- keep group and sub-group data when loading geojson polygons
- parse polygon grouping fields on GeoJSON import

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6863b2d7ba248332b62ff0b449d06c8a