### PR TITLE
Support multi-tab details for nested polygons

### DIFF
--- a/src/components/DeletionModal.jsx
+++ b/src/components/DeletionModal.jsx
@@ -15,7 +15,9 @@ import {
     Checkbox,
     Radio,
     RadioGroup,
-    Button
+    Button,
+    Tabs,
+    Tab
 } from '@mui/material';
 
 // ابتدای فایل DeletionModal.jsx
@@ -66,7 +68,10 @@ const prayerEventLabels = {
 };
 
 
-const DeletionModal = ({ selectedItem, onDelete, onClose, onEdit }) => {
+const DeletionModal = ({ selectedItems, onDelete, onClose, onEdit }) => {
+    const items = Array.isArray(selectedItems) ? selectedItems : [selectedItems];
+    const [tabIndex, setTabIndex] = useState(0);
+    const selectedItem = items[tabIndex];
     const renderTransportModes = (modes) => {
         if (!modes || modes.length === 0) return 'ندارد';
         return modes.map(mode => serviceLabels[mode] || mode).join(', ');
@@ -128,6 +133,19 @@ const DeletionModal = ({ selectedItem, onDelete, onClose, onEdit }) => {
             zIndex: 1400,
             fontSize: "13px"
         }}>
+            {items.length > 1 && (
+                <Tabs
+                    value={tabIndex}
+                    onChange={(e, v) => setTabIndex(v)}
+                    variant="scrollable"
+                    scrollButtons="auto"
+                    sx={{ marginBottom: '10px' }}
+                >
+                    {items.map((it, idx) => (
+                        <Tab key={idx} label={it.item.data?.name || it.item.name || `آیتم ${idx + 1}`} />
+                    ))}
+                </Tabs>
+            )}
             <h2 style={{
                 marginBottom: '15px',
                 textAlign: 'center',
@@ -263,7 +281,7 @@ const DeletionModal = ({ selectedItem, onDelete, onClose, onEdit }) => {
                 marginTop: '15px'
             }}>
                 <button
-                    onClick={onDelete}
+                    onClick={() => onDelete && onDelete(selectedItem)}
                     style={{
                         backgroundColor: '#dc3545',
                         color: 'white',
@@ -279,7 +297,7 @@ const DeletionModal = ({ selectedItem, onDelete, onClose, onEdit }) => {
                 </button>
                 {onEdit && (
                 <button
-                    onClick={onEdit}
+                    onClick={() => onEdit(selectedItem)}
                     style={{
                         backgroundColor: '#17a2b8',
                         color: 'white',

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -365,7 +365,7 @@ const Map = () => {
   const [selectedLocation, setSelectedLocation] = useState(null);
   const [isTracking, setIsTracking] = useState(false);
   const [showPathModal, setShowPathModal] = useState(false);
-  const [selectedItemForDeletion, setSelectedItemForDeletion] = useState(null);
+  const [selectedItemsForDeletion, setSelectedItemsForDeletion] = useState([]);
   const [markerToEdit, setMarkerToEdit] = useState(null);
   const [pathToEdit, setPathToEdit] = useState(null);
   const [polygonToEdit, setPolygonToEdit] = useState(null);
@@ -685,22 +685,16 @@ const Map = () => {
   };
 
   const handleMarkerClick = (marker) => {
-    setSelectedItemForDeletion({
-      type: 'marker',
-      item: marker
-    });
+    setSelectedItemsForDeletion([{ type: 'marker', item: marker }]);
   };
 
   const handlePathClick = (path) => {
-    setSelectedItemForDeletion({
-      type: 'path',
-      item: path
-    });
+    setSelectedItemsForDeletion([{ type: 'path', item: path }]);
   };
 
-  const handleEditSelected = () => {
-    if (!selectedItemForDeletion) return;
-    const { type, item } = selectedItemForDeletion;
+  const handleEditSelected = (selected) => {
+    if (!selected) return;
+    const { type, item } = selected;
     if (type === 'marker') {
       setMarkerToEdit(item);
     } else if (type === 'path') {
@@ -708,13 +702,13 @@ const Map = () => {
     } else if (type === 'polygon') {
       setPolygonToEdit(item);
     }
-    setSelectedItemForDeletion(null);
+    setSelectedItemsForDeletion([]);
   };
 
   // Delete handler
-  const handleDelete = () => {
-    if (selectedItemForDeletion) {
-      const { type, item } = selectedItemForDeletion;
+  const handleDelete = (selected) => {
+    if (selected) {
+      const { type, item } = selected;
 
       if (type === 'marker') {
         removeMarker(item.id);
@@ -724,7 +718,7 @@ const Map = () => {
         removePolygon(item.id);
       }
 
-      setSelectedItemForDeletion(null);
+      setSelectedItemsForDeletion([]);
     }
   };
 
@@ -791,7 +785,7 @@ const Map = () => {
 
     // If any modal is open, do nothing
     if (
-      selectedItemForDeletion ||
+      selectedItemsForDeletion.length > 0 ||
       showPolygonModal ||
       showPathModal ||
       selectedLocation
@@ -1016,12 +1010,12 @@ const Map = () => {
       )}
 
       {/* Deletion Confirmation Modal */}
-      {selectedItemForDeletion && (
+      {selectedItemsForDeletion.length > 0 && (
         <DeletionModal
-          selectedItem={selectedItemForDeletion}
+          selectedItems={selectedItemsForDeletion}
           onDelete={handleDelete}
           onEdit={handleEditSelected}
-          onClose={() => setSelectedItemForDeletion(null)}
+          onClose={() => setSelectedItemsForDeletion([])}
         />
       )}
 
@@ -1116,10 +1110,12 @@ const Map = () => {
                   e.originalEvent.stopPropagation();
                 }
                 blockNextMapClickRef.current = true;
-                setSelectedItemForDeletion({
-                  type: 'polygon',
-                  item: polygon,
-                });
+                const allPolygons = polygons.filter(pg =>
+                  isPointInPolygon({ lat: e.latlng.lat, lng: e.latlng.lng }, pg.coordinates)
+                );
+                setSelectedItemsForDeletion(
+                  allPolygons.map(pg => ({ type: 'polygon', item: pg }))
+                );
               }
             }}
           />


### PR DESCRIPTION
## Summary
- keep track of multiple clicked items
- gather all polygons under the cursor
- show deletion modal with tabs for each item

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6863df8be17883329275cec5806ca9b2