### PR TITLE
Add uniqueId to QR code link

### DIFF
--- a/src/components/DeletionModal.jsx
+++ b/src/components/DeletionModal.jsx
@@ -196,7 +196,7 @@ const DeletionModal = ({ selectedItems, onDelete, onClose, onEdit }) => {
                         selectedItem.item.position && selectedItem.item.position.length === 2 && (
                         <div style={{ textAlign: 'center', marginTop: 10 }}>
                             <QRCode
-                                value={`https://wapco-ai.github.io/golden_path/?lat=${selectedItem.item.position[0]}&lng=${selectedItem.item.position[1]}`}
+                                value={`https://wapco-ai.github.io/golden_path/?lat=${selectedItem.item.position[0]}&lng=${selectedItem.item.position[1]}&id=${selectedItem.item.data?.uniqueId}`}
                                 size={128}
                             />
                         </div>


### PR DESCRIPTION
## Summary
- include `uniqueId` as `id` in generated QR code URLs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876768e42988332b5a5af5a6e69bb0e